### PR TITLE
Db migration (plantscale -> supabase)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@builder.io/partytown": "^0.8.2",
-    "@prisma/client": "^4.1.1",
+    "@prisma/client": "^4.10.1",
     "@tanstack/react-query": "^4.29.5",
     "@trpc/client": "^9.26.2",
     "@trpc/next": "^9.26.2",
@@ -38,7 +38,7 @@
     "eslint-config-next": "12.2.3",
     "husky": "^8.0.3",
     "postcss": "^8.4.14",
-    "prisma": "^4.1.1",
+    "prisma": "^4.10.1",
     "tailwind-scrollbar": "^2.0.1",
     "tailwindcss": "^3.3.2",
     "typescript": "4.7.4"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,13 +6,14 @@ generator client {
   previewFeatures = ["referentialIntegrity"]
 }
 datasource db {
-  provider = "mysql"
+  provider = "postgresql"
   url = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
   referentialIntegrity = "prisma"
 }
 
 model Player {
-  id String @id @default(cuid())
+  id Int @id @default(0)
   firstName String
   lastName String
   position String?

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -2,12 +2,48 @@ import fetch from 'node-fetch';
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
+const TEAM_ABV_TO_ID = {
+    ARI: -1, // Arizona Cardinals
+    ATL: -2, // Atlanta Falcons
+    BAL: -3, // Baltimore Ravens
+    BUF: -4, // Buffalo Bills
+    CAR: -5, // Carolina Panthers
+    CHI: -6, // Chicago Bears
+    CIN: -7, // Cincinnati Bengals
+    CLE: -8, // Cleveland Browns
+    DAL: -9, // Dallas Cowboys
+    DEN: -10, // Denver Broncos
+    DET: -11, // Detroit Lions
+    GB: -12, // Green Bay Packers
+    HOU: -13, // Houston Texans
+    IND: -14, // Indianapolis Colts
+    JAX: -15, // Jacksonville Jaguars
+    KC: -16, // Kansas City Chiefs
+    LV: -17, // Las Vegas Raiders
+    LAC: -18, // Los Angeles Chargers
+    LAR: -19, // Los Angeles Rams
+    MIA: -20, // Miami Dolphins
+    MIN: -21, // Minnesota Vikings
+    NE: -22, // New England Patriots
+    NO: -23, // New Orleans Saints
+    NYG: -24, // New York Giants
+    NYJ: -25, // New York Jets
+    PHI: -26, // Philadelphia Eagles
+    PIT: -27, // Pittsburgh Steelers
+    SF: -28, // San Francisco 49ers
+    SEA: -29, // Seattle Seahawks
+    TB: -30, // Tampa Bay Buccaneers
+    TEN: -31, // Tennessee Titans
+    WAS: -32,
+    WSH: -32
+}
+
 const extractDataFromApiResponse = (playersDataFromSleeper) => {
     const players = Object.values(playersDataFromSleeper);
     const playersRefinedInfo = players.map((player, index) => {
         const playerNumberId = Number(player.player_id);
         return {
-            id: Number.isNaN(playerNumberId) ? -index : playerNumberId,
+            id: Number.isNaN(playerNumberId) ? TEAM_ABV_TO_ID[player.player_id] : playerNumberId,
             firstName: player.first_name,
             lastName: player.last_name,
             position: player.position,

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -4,9 +4,10 @@ const prisma = new PrismaClient();
 
 const extractDataFromApiResponse = (playersDataFromSleeper) => {
     const players = Object.values(playersDataFromSleeper);
-    const playersRefinedInfo = players.map((player) => {
+    const playersRefinedInfo = players.map((player, index) => {
+        const playerNumberId = Number(player.player_id);
         return {
-            id: player.player_id,
+            id: Number.isNaN(playerNumberId) ? -index : playerNumberId,
             firstName: player.first_name,
             lastName: player.last_name,
             position: player.position,
@@ -40,4 +41,4 @@ const seedPlayersInfo = async () => {
 }
 
 seedPlayersInfo();
-export {};
+export { };

--- a/src/features/dashboard/extractors.ts
+++ b/src/features/dashboard/extractors.ts
@@ -28,7 +28,7 @@ export const extractStartersByGame = (scheduleData: ScheduleData, timeslot: stri
             const playerTeam = playersInfo[starterId]?.team;
             return playerTeam === game.homeTeam || playerTeam === game.awayTeam;
         })
-        return {user: userStartersPerGame, opp: oppStartersPerGame};
+        return { user: userStartersPerGame, opp: oppStartersPerGame };
     })
     return startersPerGame;
 }

--- a/src/features/dashboard/player-modal/content-utils.ts
+++ b/src/features/dashboard/player-modal/content-utils.ts
@@ -1,5 +1,8 @@
+import { getTeamAbvFromDBId } from "@/features/teams/data-transfomers";
+
 export const getPlayerImageById = (playerId: string | undefined) => {
     const isDefPlayerId = Number(playerId) < 0;
-    const playerImageSrc = isDefPlayerId ? `https://sleepercdn.com/images/team_logos/nfl/${playerId?.toLowerCase()}.png` : `https://sleepercdn.com/content/nfl/players/${playerId}.jpg`
+    const teamAbvFromDBId = getTeamAbvFromDBId(Number(playerId));
+    const playerImageSrc = isDefPlayerId ? `https://sleepercdn.com/images/team_logos/nfl/${teamAbvFromDBId?.toLocaleLowerCase()}.png` : `https://sleepercdn.com/content/nfl/players/${playerId}.jpg`
     return playerImageSrc;
 };

--- a/src/features/dashboard/player-modal/content-utils.ts
+++ b/src/features/dashboard/player-modal/content-utils.ts
@@ -1,5 +1,5 @@
 export const getPlayerImageById = (playerId: string | undefined) => {
-    const isDefPlayerId = isNaN(Number(playerId));
+    const isDefPlayerId = Number(playerId) < 0;
     const playerImageSrc = isDefPlayerId ? `https://sleepercdn.com/images/team_logos/nfl/${playerId?.toLowerCase()}.png` : `https://sleepercdn.com/content/nfl/players/${playerId}.jpg`
     return playerImageSrc;
 };

--- a/src/features/leagues/data.ts
+++ b/src/features/leagues/data.ts
@@ -7,7 +7,7 @@ export const getSleeperUserLeagues = async (sleeperId: string): Promise<SleeperL
     return fetcher(`https://api.sleeper.app/v1/user/${sleeperId}/leagues/${SPORT}/${SEASON}`);
 }
 
-export const getSleeperUserRosterIds = async (sleeperId:string, leagueIds: string[]) => {
+export const getSleeperUserRosterIds = async (sleeperId: string, leagueIds: string[]) => {
     const rosterPromises = leagueIds.map(leagueId => fetcher(`https://api.sleeper.app/v1/league/${leagueId}/rosters`));
     const rosters = await Promise.all(rosterPromises);
     const leagueRosterIds = extractUserLeagueRosterIds(rosters, sleeperId);
@@ -20,7 +20,7 @@ export const getSleeperUserMatchupsData = async (leagueIds: string[], week: WEEK
     const isSingleLeague = matchupsResponse?.[0].roster_id;
     const matchups = isSingleLeague ? [matchupsResponse] : matchupsResponse;
     if (matchups.length !== leagueIds.length) throw Error('@getSleeperUserMatchupsData: Mismatch in matchups data and leagues data');
-    const leagueMatchupsData:  {[leagueId: string]: LeagueMatchup[]} = {};
+    const leagueMatchupsData: { [leagueId: string]: LeagueMatchup[] } = {};
     matchups && leagueIds.forEach((leagueId) => {
         const leagueIndex = leagueIds.findIndex(someLeagueId => someLeagueId === leagueId);
         leagueMatchupsData[leagueId] = matchups?.[leagueIndex]

--- a/src/features/teams/data-transfomers.ts
+++ b/src/features/teams/data-transfomers.ts
@@ -1,0 +1,46 @@
+const TEAM_ABV_TO_ID: Record<string, number> = {
+    ARI: -1, // Arizona Cardinals
+    ATL: -2, // Atlanta Falcons
+    BAL: -3, // Baltimore Ravens
+    BUF: -4, // Buffalo Bills
+    CAR: -5, // Carolina Panthers
+    CHI: -6, // Chicago Bears
+    CIN: -7, // Cincinnati Bengals
+    CLE: -8, // Cleveland Browns
+    DAL: -9, // Dallas Cowboys
+    DEN: -10, // Denver Broncos
+    DET: -11, // Detroit Lions
+    GB: -12, // Green Bay Packers
+    HOU: -13, // Houston Texans
+    IND: -14, // Indianapolis Colts
+    JAX: -15, // Jacksonville Jaguars
+    KC: -16, // Kansas City Chiefs
+    LV: -17, // Las Vegas Raiders
+    LAC: -18, // Los Angeles Chargers
+    LAR: -19, // Los Angeles Rams
+    MIA: -20, // Miami Dolphins
+    MIN: -21, // Minnesota Vikings
+    NE: -22, // New England Patriots
+    NO: -23, // New Orleans Saints
+    NYG: -24, // New York Giants
+    NYJ: -25, // New York Jets
+    PHI: -26, // Philadelphia Eagles
+    PIT: -27, // Pittsburgh Steelers
+    SF: -28, // San Francisco 49ers
+    SEA: -29, // Seattle Seahawks
+    TB: -30, // Tampa Bay Buccaneers
+    TEN: -31, // Tennessee Titans
+    WAS: -32,
+    WSH: -32
+};
+
+export const getDBIdFromTeamAbv = (teamAbv: string) => {
+    const dbId = TEAM_ABV_TO_ID[teamAbv];
+    if (!dbId) return 0;
+    return dbId;
+}
+
+export const getTeamAbvFromDBId = (dbId: number) => {
+    const teamAbv = Object.keys(TEAM_ABV_TO_ID).find(key => TEAM_ABV_TO_ID[key] === dbId);
+    return teamAbv;
+}

--- a/src/server/router/players.ts
+++ b/src/server/router/players.ts
@@ -9,12 +9,12 @@ export const playersRouter = createRouter()
       playerIds: z.array(z.string())
     }).nullish(),
     async resolve({ input }) {
-      const noDuplicatePlayerIds = Array.from(new Set(input?.playerIds ?? []));
+      const noDuplicatePlayerIds = Array.from(new Set(input?.playerIds ?? [])).map(id => Number(id));
       const playersInfo = await prisma.player.findMany({
-        where: {id: {in: noDuplicatePlayerIds} }
+        where: { id: { in: noDuplicatePlayerIds } }
       });
-      const playersInfoById: Record<string, Player> = playersInfo.reduce((acc, player) => {
-        return {...acc, [player.id]: {...player, team: player.team === 'WAS' ? 'WSH' : player.team}};
+      const playersInfoById: Record<string, Omit<Player, "id"> & { id?: string }> = playersInfo.reduce((acc, player) => {
+        return { ...acc, [player.id]: { ...player, team: player.team === 'WAS' ? 'WSH' : player.team, id: player.id?.toString() ?? '' } };
       }, {})
       return playersInfoById;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,22 +1118,22 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@prisma/client@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.1.1.tgz#dcb1118397deb8247fbe39a1f3eee5606648adf8"
-  integrity sha512-2pXuIUYxHv5H9o6QTa1VIsl4yMgsAjKQOitlo8WVTB+vo73rmMJITBPavdGUZSWUc7adMkFzEV3y5rVTUQr77Q==
+"@prisma/client@^4.10.1":
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.16.2.tgz#3bb9ebd49b35c8236b3d468d0215192267016e2b"
+  integrity sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==
   dependencies:
-    "@prisma/engines-version" "4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8"
+    "@prisma/engines-version" "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
 
-"@prisma/engines-version@4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8":
-  version "4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.1.0-48.8d8414deb360336e4698a65aa45a1fbaf1ce13d8.tgz#ce00e6377126e491a8b1e0e2039c97e2924bd6d9"
-  integrity sha512-cRRJwpHFGFJZvtHbY3GZjMffNBEjjZk68ztn+S2hDgPCGB4H66IK26roK94GJxBodSehwRJ0wGyebC2GoIH1JQ==
+"@prisma/engines-version@4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81":
+  version "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz#d3b5dcf95b6d220e258cbf6ae19b06d30a7e9f14"
+  integrity sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg==
 
-"@prisma/engines@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.1.1.tgz#a6a75870618bbd19ff734c51af7dbe9f362c3265"
-  integrity sha512-DCw8L/SS0IXqmj5IW/fMxOXiifnsfjBzDfRhf0j3NFWqvMCh9OtfjmXQZxVgI2mwvJLc/5jzXhkiWT39qS09dA==
+"@prisma/engines@4.16.2":
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.16.2.tgz#5ec8dd672c2173d597e469194916ad4826ce2e5f"
+  integrity sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -3576,12 +3576,12 @@ pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
-prisma@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.1.1.tgz#41c2e19896357f484ef21567165d762908376fca"
-  integrity sha512-yw50J8If2dKP4wYIi695zthsCASQFHiogGvUHHWd3falx/rpsD6Sb1LMLRV9nO3iGG3lozxNJ2PSINxK7xwdpg==
+prisma@^4.10.1:
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.16.2.tgz#469e0a0991c6ae5bcde289401726bb012253339e"
+  integrity sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==
   dependencies:
-    "@prisma/engines" "4.1.1"
+    "@prisma/engines" "4.16.2"
 
 prop-types@^15.8.1:
   version "15.8.1"


### PR DESCRIPTION
Plantscale ended its free hobby plan, so RIP.
Since my DB is practically a cache and I don't really need a migration to move the data from plantscale to any new DB host I could choose any service I wanted (note that Supabase is postgress compared to PS's mysql).
Supabase just seemed the most easy and "trendy" DB host atm so I knew it would be fairly easy to get information on how to onboard.
Went pretty smooth, the only relevant changes here to the codebase is changing the `id` field in the DB to a number (from String) so I had to:

- Give meaningful numbers to DEFs (which in the sleeper API do not have numbered IDs, so I went with constant negative numbers).
- Apply the changes from `number` to `string` in my client side code, I opted to "lie" on my tRPC type since __I am__ smarter than him knowing what I get from the endpoint and since it required the least amount of changes to actual UI/business-logic code.

Another very relevant change in this PR is the seeding script which now supports the Supabase schema.

Longterm I'd look into other forms of DB hosting since I really only need a cache for the massive players info API call.