### PR TITLE
color highlighted players on plain dashboard view

### DIFF
--- a/src/features/dashboard/timeslots/content-utils.ts
+++ b/src/features/dashboard/timeslots/content-utils.ts
@@ -11,22 +11,23 @@ export const getCondensedTimeslotString = (timeslot: string) => {
     return timeslotDate.toLocaleString('en', { weekday: 'short', hour: 'numeric', minute: 'numeric' });
 };
 
-export const getStarterEmoji = (multipliers?: number, isConflicted?: boolean, isUserTeam?: boolean) => {
-    if (isConflicted) return EMOJIES.SWORDS_EMOJI;
-    const isUnconflictedMultiplier = multipliers && multipliers > 1 && !isConflicted;
+export const getStarterHighlightType = (multipliers?: number, isConflicted?: boolean, isUserTeam?: boolean): HighlightedPlayerType | null => {
+    if (isConflicted) return HIGHLIGHTED_PLAYER_TYPES.CONFLICTED;
+    const isUnconflictedMultiplier = multipliers && multipliers > 1;
     const isRoot = isUnconflictedMultiplier && isUserTeam;
-    if (isRoot) return EMOJIES.THUNDER_EMOJI;
+    if (isRoot) return HIGHLIGHTED_PLAYER_TYPES.ROOT;
     const isBoo = isUnconflictedMultiplier && !isUserTeam;
-    if (isBoo) return EMOJIES.THUMBS_DOWN_EMOJI;
+    if (isBoo) return HIGHLIGHTED_PLAYER_TYPES.BOO;
+    return null;
 }
 
 export const getHighlightStyle = (highlightType: HighlightedPlayerType) => {
     switch (highlightType) {
         case HIGHLIGHTED_PLAYER_TYPES.CONFLICTED:
-            return {emoji: EMOJIES.SWORDS_EMOJI, backgroundColor: 'bg-yellow-200'};
+            return { emoji: EMOJIES.SWORDS_EMOJI, backgroundColor: 'bg-yellow-200', textColor: 'text-yellow-200' };
         case HIGHLIGHTED_PLAYER_TYPES.ROOT:
-            return {emoji: EMOJIES.THUNDER_EMOJI, backgroundColor: 'bg-emerald-500'};
+            return { emoji: EMOJIES.THUNDER_EMOJI, backgroundColor: 'bg-emerald-500', textColor: 'text-emerald-500' };
         case HIGHLIGHTED_PLAYER_TYPES.BOO:
-            return {emoji: EMOJIES.THUMBS_DOWN_EMOJI, backgroundColor: 'bg-red-500'};
+            return { emoji: EMOJIES.THUMBS_DOWN_EMOJI, backgroundColor: 'bg-red-500', textColor: 'text-red-500' };
     }
 }

--- a/src/features/dashboard/timeslots/starters/StarterRow.tsx
+++ b/src/features/dashboard/timeslots/starters/StarterRow.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { getStarterEmoji } from '../content-utils';
+import { getStarterHighlightType, getHighlightStyle } from '../content-utils';
 import PlayerModalContext from '../../player-modal/PlayerModalContext';
 import { logStarterClicked } from '../../bi';
 
@@ -19,7 +19,8 @@ interface StarterRowProps {
 
 const StarterRow: React.FC<StarterRowProps> = (props) => {
     const { id, position, firstName, lastName, team, multipliers, isConflicted, oppTeam, isHome, isUser: isUserTeam, isByGameView } = props;
-    const starterEmoji = getStarterEmoji(multipliers, isConflicted, isUserTeam);
+    const highlightType = getStarterHighlightType(multipliers, isConflicted, isUserTeam);
+    const highlightStyle = highlightType ? getHighlightStyle(highlightType) : null;
     const { openPlayerModal } = useContext(PlayerModalContext);
 
     const onStarterClick = () => {
@@ -30,11 +31,11 @@ const StarterRow: React.FC<StarterRowProps> = (props) => {
     return (
         <li className='flex items-center cursor-pointer py-2' onClick={onStarterClick}>
             <div className={`text-sm pb-1 md:text-base grid grid-cols-4
-            w-full ${starterEmoji ? 'font-bold' : ''}`}>
+            w-full ${highlightStyle ? `font-bold ${highlightStyle.textColor}` : ''}`}>
                 <div className='flex w-full col-span-3'>
-                    <p className='w-[4ch]'>{`${position}`}</p>
+                    <p className={'w-[4ch]'}>{`${position}`}</p>
                     <p>
-                        <span className={`hidden md:inline pr-1 lg:pr-2`}>{starterEmoji}</span>
+                        <span className={`hidden md:inline pr-1 lg:pr-2`}>{highlightStyle?.emoji}</span>
                         <span className="hidden sm:inline">{`${firstName}\t\t`}</span>
                         <span>{lastName}</span>
                         {multipliers && multipliers > 1 && <span className='hidden lg:inline'>{` (X${multipliers})`}</span>}


### PR DESCRIPTION
Add visibility (especially on mobile) for highlighted players in the timeslots view (add color like in highlighted players section).